### PR TITLE
Remove calls to deleted file

### DIFF
--- a/prestasms/src/ProxyGenerator.php
+++ b/prestasms/src/ProxyGenerator.php
@@ -24,7 +24,7 @@ class ProxyGenerator extends Extensions\Strict
         $this->token = (string) $token;
     }
 
-    public function add($action, $proxy_action, $reducer = '_generic', $url = 'ajax-tab.php')
+    public function add($action, $proxy_action, $reducer = '_generic', $url = 'index.php')
     {
         $proxy = array(
             'url' => $url,

--- a/templates/base.tpl
+++ b/templates/base.tpl
@@ -32,7 +32,7 @@
 
         var _bg_client_config = {
             url: {
-                authenticationService : 'ajax-tab.php',
+                authenticationService : 'index.php',
             },
             actions: {
                 authenticate: function () {

--- a/templates/panel.tpl
+++ b/templates/panel.tpl
@@ -10,7 +10,7 @@
         <script type="application/javascript">
             var _bg_client_config = {
                 url: {
-                    authenticationService : 'ajax-tab.php',
+                    authenticationService : 'index.php',
                 },
                 actions: {
                     authenticate: function () {


### PR DESCRIPTION
On some stores, any module controller I open are infinitely spinning, because of calls to /admin/ajax-tab.php file. This file was removed in PrestaShop 8.0.

https://github.com/PrestaShop/PrestaShop/blob/1.7.8.11/admin-dev/ajax-tab.php
https://github.com/PrestaShop/PrestaShop/blob/8.0.0-beta.1/admin-dev/ajax-tab.php

The fix is to simply call index.php directly, as the file was doing before.

![issue](https://github.com/BulkGate/prestasms/assets/6097524/b04e346c-eae3-4090-a6a3-72f82265554f)
![Snímek obrazovky 2024-05-21 120247](https://github.com/BulkGate/prestasms/assets/6097524/c20ed56c-f5bd-4ec3-9404-5d2f96392784)
![Snímek obrazovky 2024-05-21 120318](https://github.com/BulkGate/prestasms/assets/6097524/a33cbba9-ecf0-425f-8102-d21e44819a89)
